### PR TITLE
Add request rate limit counter & report agent rate limit config

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -303,8 +303,10 @@ type ListSpecsResponse struct {
 	LastPage bool `json:"last_page"`
 }
 
-type TimelineAggregation string
-type TimelineValue string
+type (
+	TimelineAggregation string
+	TimelineValue       string
+)
 
 // Time along with a map of values such as
 // count, latency, etc.
@@ -542,6 +544,9 @@ type PostClientPacketCaptureStatsRequest struct {
 
 	// Report CPU and memory usage, if available.
 	AgentResourceUsage *AgentResourceUsage `json:"agent_resource_usage,omitempty"`
+
+	// Currently configured agent rate limit
+	AgentRateLimit float64 `json:"agent_rate_limit,omitempty"`
 }
 
 type AgentResourceUsage struct {
@@ -595,6 +600,9 @@ type PostInitialClientTelemetryRequest struct {
 	// like a container looks like a VM.  Maybe we can do something for sidecars.
 	AgentPodName     string `json:"agent_pod_name,omitempty"`
 	MonitoredPodName string `json:"monitored_pod_name,omitempty"`
+
+	// Currently configured agent rate limit
+	AgentRateLimit float64 `json:"agent_rate_limit,omitempty"`
 }
 
 type UserResponse struct {

--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -11,20 +11,22 @@ type PacketCounts struct {
 	DstPort   int    `json:"dst_port"`
 
 	// Number of events
-	TCPPackets         int `json:"tcp_packets"`
-	HTTPRequests       int `json:"http_requests"`
-	HTTPResponses      int `json:"http_responses"`
-	OversizedWitnesses int `json:"oversized_witnesses"` // These witnesses were dropped.
-	TLSHello           int `json:"tls_hello"`
-	HTTP2Prefaces      int `json:"http2_prefaces"`
-	QUICHandshakes     int `json:"quic_handshakes"`
-	Unparsed           int `json:"unparsed"`
+	TCPPackets              int `json:"tcp_packets"`
+	HTTPRequests            int `json:"http_requests"`
+	HTTPResponses           int `json:"http_responses"`
+	HTTPRequestsRateLimited int `json:"http_requests_rate_limited"`
+	OversizedWitnesses      int `json:"oversized_witnesses"` // These witnesses were dropped.
+	TLSHello                int `json:"tls_hello"`
+	HTTP2Prefaces           int `json:"http2_prefaces"`
+	QUICHandshakes          int `json:"quic_handshakes"`
+	Unparsed                int `json:"unparsed"`
 }
 
 func (c *PacketCounts) Add(d PacketCounts) {
 	c.TCPPackets += d.TCPPackets
 	c.HTTPRequests += d.HTTPRequests
 	c.HTTPResponses += d.HTTPResponses
+	c.HTTPRequestsRateLimited += d.HTTPRequestsRateLimited
 	c.OversizedWitnesses += d.OversizedWitnesses
 	c.TLSHello += d.TLSHello
 	c.HTTP2Prefaces += d.HTTP2Prefaces


### PR DESCRIPTION
Introduces a new event counter: `HTTPRequestsRateLimited` in `PacketCounts`. The counter will:
- Get incremented here in the agent. 
- Get reported by the telemetry worker on the default interval to the `/v2/agent/services/%s/telemetry/client/deployment` endpoint. 
- Get stored in the `packet_count_summary` JSONB column in the `client_packet_capture_stats` table.

Includes the agent's rate limit in:
- Calls to `/v2/agent/services/%s/telemetry/client/deployment` endpoint = `PostClientPacketCaptureStats` API.
- Calls to `/v2/agent/services/%s/telemetry/client/deployment/start` endpoint = `PostInitialClientTelemetry` API.

I'm not sure yet if I'll need the agent rate limit on both calls. Once I flesh out the backend portion better I'll know for sure. 