### PR TITLE
Allow PacketCounts to be reset

### DIFF
--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -61,7 +61,7 @@ func (c *PacketCounts) CopyAndReset() *PacketCounts {
 // Reflects the version of the JSON encoding.  Increase the minor version
 // number for backwards-compatible changes and the major number for non-
 // backwards compatible changes.
-const Version = "v0.3"
+const Version = "v0.4"
 
 type PacketCountSummary struct {
 	Version           string                   `json:"version"`

--- a/client_telemetry/pcap_stats.go
+++ b/client_telemetry/pcap_stats.go
@@ -42,17 +42,34 @@ func (c *PacketCounts) Copy() *PacketCounts {
 	return &copy
 }
 
+func (c *PacketCounts) CopyAndReset() *PacketCounts {
+	copy := c.Copy()
+
+	c.TCPPackets = 0
+	c.HTTPRequests = 0
+	c.HTTPResponses = 0
+	c.HTTPRequestsRateLimited = 0
+	c.OversizedWitnesses = 0
+	c.TLSHello = 0
+	c.HTTP2Prefaces = 0
+	c.QUICHandshakes = 0
+	c.Unparsed = 0
+
+	return copy
+}
+
 // Reflects the version of the JSON encoding.  Increase the minor version
 // number for backwards-compatible changes and the major number for non-
 // backwards compatible changes.
 const Version = "v0.3"
 
 type PacketCountSummary struct {
-	Version        string                   `json:"version"`
-	Total          PacketCounts             `json:"total"`
-	TopByPort      map[int]*PacketCounts    `json:"top_by_port"`
-	TopByInterface map[string]*PacketCounts `json:"top_by_interface"`
-	TopByHost      map[string]*PacketCounts `json:"top_by_host"`
+	Version           string                   `json:"version"`
+	Total             PacketCounts             `json:"total"`
+	ObservationWindow PacketCounts             `json:"observation_window"`
+	TopByPort         map[int]*PacketCounts    `json:"top_by_port"`
+	TopByInterface    map[string]*PacketCounts `json:"top_by_interface"`
+	TopByHost         map[string]*PacketCounts `json:"top_by_host"`
 
 	// Maximum number of elements allowed in the TopByX maps.
 	ByPortOverflowLimit      int `json:"by_port_overflow_limit"`


### PR DESCRIPTION
I ran into a couple of roadblocks with previous plan for calculating per agent throughput and total throughput with just the cumulative count. I have settled on the following plan:

- Introduce a new set of counters, `ObservationWindow` though open to alternative names, that reset each time we send a `PacketCountSummary`.
- Use the counts in the observation window to build a time series table.
- Query the time series table over a time period to determine the number of agents that reported rate limited request and sum the number of requests processed in that time period.