### PR TITLE
[POA-3519] Capture observation window start and duration

### DIFF
--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -530,9 +530,11 @@ const (
 )
 
 type PostClientPacketCaptureStatsRequest struct {
-	ClientID                  akid.ClientID `json:"client_id"`
-	ObservedStartingAt        time.Time     `json:"observed_starting_at"`
-	ObservedDurationInSeconds int           `json:"observed_duration_in_seconds"`
+	ClientID                        akid.ClientID `json:"client_id"`
+	ObservedStartingAt              time.Time     `json:"observed_starting_at"`
+	ObservedDurationInSeconds       int           `json:"observed_duration_in_seconds"`
+	ObservedWindowStartingAt        time.Time     `json:"observed_window_starting_at"`
+	ObservedWindowDurationInSeconds int           `json:"observed_window_duration_in_seconds"`
 
 	// If PacketCountSummary is absent, then this observation period has
 	// started but not yet concluded.


### PR DESCRIPTION
Introduces two new properties: `ObservedWindowStartingAt` and `ObservedWindowDurationInSeconds`. The latter will help us calculate averages requests per minute more precisely. Today we can calculate requests per minute as such:
```
requests * 60 / ObservedDurationInSeconds 
```
The problem with this calculation is that over a long time it will flatten the average. Dividing by a smaller time window, `ObservedWindowDurationInSeconds` will keep the averages from being flatten. `ObservedWindowDurationInSeconds` is the number of seconds since the previous telemetry report.

The `ObservedWindowStartingAt` property will be used as the timestamp in rollup calculations.