### PR TITLE
[eBPF] Add net traffic direction

### DIFF
--- a/akinet/net_traffic.go
+++ b/akinet/net_traffic.go
@@ -16,6 +16,29 @@ import (
 	"github.com/akitasoftware/akita-libs/memview"
 )
 
+// NetTrafficDirection indicates, relative to the monitored service, whether an
+// HTTP exchange is inbound (the service is the server: it received the request)
+// or outbound (the service is the client: it sent the request). It is
+// DirectionUnknown when the producer does not compute it (e.g. the pcap path).
+type NetTrafficDirection int
+
+const (
+	DirectionUnknown NetTrafficDirection = iota
+	DirectionInbound
+	DirectionOutbound
+)
+
+func (d NetTrafficDirection) String() string {
+	switch d {
+	case DirectionInbound:
+		return "INBOUND"
+	case DirectionOutbound:
+		return "OUTBOUND"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // Represents a generic network traffic that has been parsed from the wire.
 type ParsedNetworkTraffic struct {
 	SrcIP     net.IP
@@ -24,6 +47,11 @@ type ParsedNetworkTraffic struct {
 	DstPort   int
 	Content   ParsedNetworkContent
 	Interface string
+
+	// Direction, when known, indicates whether this traffic is inbound or
+	// outbound relative to the monitored service. DirectionUnknown for
+	// producers that do not compute it.
+	Direction NetTrafficDirection
 
 	// The time at which the first packet was observed
 	ObservationTime time.Time

--- a/api_schema/schema.go
+++ b/api_schema/schema.go
@@ -17,7 +17,8 @@ import (
 type NetworkDirection string
 
 const (
-	Inbound NetworkDirection = "INBOUND"
+	Inbound  NetworkDirection = "INBOUND"
+	Outbound NetworkDirection = "OUTBOUND"
 )
 
 type APISpecState string


### PR DESCRIPTION
This pull request introduces a new way to represent the direction of network traffic relative to a monitored service, making it clearer whether traffic is inbound or outbound. The main changes include the addition of a `NetTrafficDirection` type and its integration into the `ParsedNetworkTraffic` struct, as well as an update to the API schema to include the outbound direction.

**Network traffic direction support:**

* Added the `NetTrafficDirection` type, including the `DirectionUnknown`, `DirectionInbound`, and `DirectionOutbound` constants, along with a `String()` method for readable output (`akinet/net_traffic.go`).
* Updated the `ParsedNetworkTraffic` struct to include a `Direction` field, allowing each network traffic instance to specify its direction relative to the monitored service (`akinet/net_traffic.go`).

**API schema update:**

* Added the `Outbound` value to the `NetworkDirection` type to support outbound traffic in the API schema (`api_schema/schema.go`).